### PR TITLE
Possibility to set clipboard command

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Usage of andcli:
         Path to the encrypted vault
   -t string
         Vault type (andotp, aegis)
+  -c string
+        Clipboard command (by default is the first of `xclip`, `wl-copy` or `pbcopy` found)
   -v    Show current version
 ```
 

--- a/cmd/andcli/config.go
+++ b/cmd/andcli/config.go
@@ -10,11 +10,12 @@ import (
 )
 
 type config struct {
-	File string `yaml:"file"`
-	Type string `yaml:"type"`
+	File         string `yaml:"file"`
+	Type         string `yaml:"type"`
+	ClipboardCmd string `yaml:"clipboard_cmd"`
 }
 
-func newConfig(vaultFile, vaultType string) (*config, error) {
+func newConfig(vaultFile, vaultType, clipboardCmd string) (*config, error) {
 	var err error
 
 	if vaultFile != "" {
@@ -60,6 +61,10 @@ func newConfig(vaultFile, vaultType string) (*config, error) {
 
 	if vaultType != "" {
 		cfg.Type = vaultType
+	}
+
+	if clipboardCmd != "" {
+		cfg.ClipboardCmd = clipboardCmd
 	}
 
 	if _, ok := os.LookupEnv("ANDCLI_HIDE_ABSPATH"); !ok {

--- a/cmd/andcli/main.go
+++ b/cmd/andcli/main.go
@@ -61,11 +61,12 @@ func init() {
 }
 
 func main() {
-	var vaultFile, vaultType string
+	var vaultFile, vaultType, clipboardCmd string
 	var showVersion bool
 
 	flag.StringVar(&vaultFile, "f", "", "Path to the encrypted vault")
 	flag.StringVar(&vaultType, "t", "", "Vault type (andotp, aegis)")
+	flag.StringVar(&clipboardCmd, "c", "", "Clipboard command (xclip, wl-copy, pbcopy, etc.)")
 	flag.BoolVar(&showVersion, "v", false, "Show current version")
 	flag.Parse()
 
@@ -83,7 +84,7 @@ func main() {
 
 	prefix := danger.Sprint("[ERR]")
 
-	cfg, err := newConfig(vaultFile, vaultType)
+	cfg, err := newConfig(vaultFile, vaultType, clipboardCmd)
 	if err != nil {
 		log.Fatalf("%s: %s\n", prefix, err.Error())
 	}
@@ -108,7 +109,7 @@ func main() {
 	output := termenv.DefaultOutput()
 	output.ClearScreen()
 
-	p := tea.NewProgram(newModel(output, cfg.File, entries...))
+	p := tea.NewProgram(newModel(output, cfg.File, cfg.ClipboardCmd, entries...))
 	if _, err := p.Run(); err != nil {
 		log.Fatalf("%s: %s\n", prefix, err.Error())
 	}

--- a/cmd/andcli/main.go
+++ b/cmd/andcli/main.go
@@ -34,10 +34,8 @@ var (
 	muted   = color.New(color.FgHiWhite, color.Faint)
 
 	// global ui stuff
-	copyCmd            = ""
-	current            = "" // holds an unformatted copy of the current token
-	copied             = false
-	copiedVisibleMSecs = 2000
+	copyCmd = ""
+	current = "" // holds an unformatted copy of the current token
 
 	// build vars
 	commit = ""

--- a/cmd/andcli/tea.go
+++ b/cmd/andcli/tea.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"log"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -14,15 +13,18 @@ import (
 
 type (
 	model struct {
-		filename string
-		items    entries
-		filtered entries
-		cursor   int
-		selected int
-		view     string
-		visible  bool
-		query    string
-		output   *termenv.Output
+		filename           string
+		items              entries
+		filtered           entries
+		cursor             int
+		selected           int
+		view               string
+		visible            bool
+		query              string
+		output             *termenv.Output
+		copied             bool
+		copyFailed         bool
+		copiedVisibleMSecs int
 	}
 
 	tickMsg struct{}
@@ -30,11 +32,14 @@ type (
 
 func newModel(o *termenv.Output, filename, cfgClipboardCmd string, entries ...entry) *model {
 	m := &model{
-		filename: filename,
-		items:    entries,
-		selected: -1,
-		view:     VIEW_LIST,
-		output:   o,
+		filename:           filename,
+		items:              entries,
+		selected:           -1,
+		view:               VIEW_LIST,
+		output:             o,
+		copied:             false,
+		copyFailed:         false,
+		copiedVisibleMSecs: 2000,
 	}
 
 	if cfgClipboardCmd != "" {
@@ -171,20 +176,22 @@ func (m *model) updateDetail(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if current != "" && copyCmd != "" {
 					cmd := fmt.Sprintf("echo %s | %s", current, copyCmd)
 					if err := exec.Command("sh", "-c", cmd).Run(); err != nil {
-						log.Println("copy:", err)
-						return m, tea.Quit
+						m.copyFailed = true
+						m.copied = false
+						return m, nil
 					}
-					copied = true
+					m.copyFailed = false
+					m.copied = true
 				}
 			}
 		}
 	case tickMsg:
-		if copied {
-			if copiedVisibleMSecs > 0 {
-				copiedVisibleMSecs--
+		if m.copied {
+			if m.copiedVisibleMSecs > 0 {
+				m.copiedVisibleMSecs--
 			} else {
-				copied = false
-				copiedVisibleMSecs = 2000
+				m.copied = false
+				m.copiedVisibleMSecs = 2000
 			}
 		}
 
@@ -237,8 +244,12 @@ func (m *model) detail() string {
 		fmtUntil = danger.Sprintf("%ds", until)
 	}
 
-	if copied {
+	if m.copied {
 		fmtToken += success.Sprint(" ✓ ")
+	}
+
+	if m.copyFailed {
+		fmtToken += danger.Sprint(" ✗ \nCopy command (" + copyCmd + ") failed, check your configuration!")
 	}
 
 	view := fmt.Sprintf("%s: %s\nValid: %s\n", name, fmtToken, fmtUntil)

--- a/cmd/andcli/tea.go
+++ b/cmd/andcli/tea.go
@@ -28,7 +28,7 @@ type (
 	tickMsg struct{}
 )
 
-func newModel(o *termenv.Output, filename string, entries ...entry) *model {
+func newModel(o *termenv.Output, filename, cfgClipboardCmd string, entries ...entry) *model {
 	m := &model{
 		filename: filename,
 		items:    entries,
@@ -37,11 +37,15 @@ func newModel(o *termenv.Output, filename string, entries ...entry) *model {
 		output:   o,
 	}
 
-	cmds := []string{"xclip", "wl-copy", "pbcopy"} // xorg, wayland, macos
-	for _, c := range cmds {
-		if _, err := exec.LookPath(c); err == nil {
-			copyCmd = c
-			break
+	if cfgClipboardCmd != "" {
+		copyCmd = cfgClipboardCmd
+	} else {
+		cmds := []string{"xclip", "wl-copy", "pbcopy"} // xorg, wayland, macos
+		for _, c := range cmds {
+			if _, err := exec.LookPath(c); err == nil {
+				copyCmd = c
+				break
+			}
 		}
 	}
 


### PR DESCRIPTION
Since I both have `xclip` and `wl-copy` installed and I don't want to uninstall `xclip`, I wanted to be able to manually set the clipboard copy command.

You can now set it via:
- command line flag `-c`
- configuration option `clipboard_cmd`

If not set, it falls back to the old autodetect mechanism.