### PR TITLE
fix: add missing equals sign to git describe command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ NOW=$(shell date "+%F %T%:z")
 FLAGS=-s -w -X 'main.commit=$(COMMIT)' -X 'main.gover=$(GOVER)' -X 'main.date=$(NOW)'
 
 # set local vars without pipeline access
-TAG=$(shell git describe --tags --abbrev 0)
+TAG=$(shell git describe --tags --abbrev=0)
 ARCH=$(shell go env GOARCH)
 
 build: clean


### PR DESCRIPTION
Running `make build` throws the error `fatal: Not a valid object name 0` because of a missing equals sign in the `git describe` command. This occurred on Manjaro Linux x64 with zsh shell.