### PR TITLE
Fix 2FAS format not using account as fallback

### DIFF
--- a/internal/vaults/twofas/twofas.go
+++ b/internal/vaults/twofas/twofas.go
@@ -124,10 +124,16 @@ func (v vault) Entries() []vaults.Entry {
 			e.Otp.Digits = 6
 		}
 
+		label := e.Otp.Label
+
+		if label == "" {
+			label = e.Otp.Account
+		}
+
 		entries = append(entries, vaults.Entry{
 			Secret:    e.Secret,
 			Issuer:    e.Otp.Issuer,
-			Label:     e.Otp.Label,
+			Label:     label,
 			Digits:    e.Otp.Digits,
 			Type:      e.Otp.TokenType,
 			Algorithm: e.Otp.Algorithm,


### PR DESCRIPTION
Hey, thanks for your work. I really like the TUI!

Looks like there is an issue with 2FAS backups, when there is no `otp.label` attribute present. No usernames will be shown.

![Screenshot 2025-06-18 at 09 40 21](https://github.com/user-attachments/assets/2dfa60af-acb3-4baa-812c-a6afddb2295a)

```json
{
    "updatedAt": 1750228374000,
    "secret": "SECRETSECRETSECRETSECRET",
    "serviceTypeID": "UUID-UUID-UUID",
    "icon": {
        "selected": "IconCollection",
        "iconCollection": { "id": "UUID-UUID-UUID" },
        "label": { "backgroundColor": "LightBlue", "text": "AM" }
    },
    "order": { "position": 1 },
    "otp": {
        "account": "foo@bar.com",
        "counter": 0,
        "period": 30,
        "algorithm": "SHA1",
        "issuer": "Amazon",
        "tokenType": "TOTP",
        "link": "otpauth:\/\/totp\/Amazon:foo@bar.com?secret=[hidden]&algorithm=sha1&period=30&digits=6&issuer=Amazon",
        "digits": 6,
        "source": "link"
    },
    "name": "Amazon"
}
```

I've added a fallback to the `otp.account` attribute in case the `otp.label` is empty.