### PR TITLE
Add newline after password prompt.

### DIFF
--- a/internal/input/input.go
+++ b/internal/input/input.go
@@ -18,5 +18,7 @@ func AskHidden(question string, defaults ...[]byte) ([]byte, error) {
 	}
 
 	fmt.Printf("%s", question)
-	return term.ReadPassword(fd)
+	password, err := term.ReadPassword(fd)
+	fmt.Println()
+	return password, err
 }


### PR DESCRIPTION

Suggestion: Having the error message appear on the same line as `Password: ` looks weird to me as most CLI applications have the error message on a newline.

---

Before

```bash
Opening /path/to/export.json ...
Password: andcli: aegis: cipher: message authentication failed
```

After

```bash
Opening /path/to/export.json ...
Password:
andcli: aegis: cipher: message authentication failed
```